### PR TITLE
Check for corefoundation classes starting with __NSCF prefix

### DIFF
--- a/Source/MAZeroingWeakRef.m
+++ b/Source/MAZeroingWeakRef.m
@@ -330,7 +330,8 @@ static BOOL IsTollFreeBridged(Class class, id obj)
     Class tfbClass = __CFRuntimeObjCClassTable[typeID];
     return class == tfbClass;
 #else
-    return [NSStringFromClass(class) hasPrefix: @"NSCF"];
+    NSString *className = NSStringFromClass(class);
+    return [className hasPrefix:@"NSCF"] || [className hasPrefix:@"__NSCF"];
 #endif
 }
 


### PR DESCRIPTION
This checks for any toll free bridged classes that start with the __NSCF prefix -- in case in any future releases of the OS, uh, change the name of the toll free bridged classes.
