### PR TITLE
Ignore Constant Objects

### DIFF
--- a/Source/MAZeroingWeakRef.m
+++ b/Source/MAZeroingWeakRef.m
@@ -335,6 +335,11 @@ static BOOL IsTollFreeBridged(Class class, id obj)
 #endif
 }
 
+static BOOL IsConstantObject(id obj)
+{
+  return (unsigned int)[obj retainCount] == UINT_MAX;
+}
+
 #if COREFOUNDATION_HACK_LEVEL >= 3
 void _CFRelease(CFTypeRef cf);
 
@@ -436,7 +441,7 @@ static Class CreateCustomSubclass(Class class, id obj)
             gCFOriginalFinalizes[typeID] = cfclass->finalize;
         } while(!OSAtomicCompareAndSwapPtrBarrier(gCFOriginalFinalizes[typeID], CustomCFFinalize, (void *)&cfclass->finalize));
 #else
-        NSCAssert(0, @"Cannot create zeroing weak reference to object of type %@ with COREFOUNDATION_HACK_LEVEL set to %d", class, COREFOUNDATION_HACK_LEVEL);
+        NSCAssert(0, @"Cannot create zeroing weak reference to object of type %@ with COREFOUNDATION_HACK_LEVEL set to %d", class, COREFOUNDATION_HACK_LEVEL);          
 #endif
         return class;
     }
@@ -476,7 +481,7 @@ static Class CreateCustomSubclass(Class class, id obj)
 
 static void EnsureCustomSubclass(id obj)
 {
-    if(!GetCustomSubclass(obj))
+    if(!GetCustomSubclass(obj) && !IsConstantObject(obj))
     {
         Class class = object_getClass(obj);
         Class subclass = [gCustomSubclassMap objectForKey: class];

--- a/Source/MAZeroingWeakRef.m
+++ b/Source/MAZeroingWeakRef.m
@@ -337,7 +337,8 @@ static BOOL IsTollFreeBridged(Class class, id obj)
 
 static BOOL IsConstantObject(id obj)
 {
-  return (unsigned int)[obj retainCount] == UINT_MAX;
+  unsigned int retainCount = [obj retainCount];
+  return retainCount == UINT_MAX || retainCount == INT_MAX;
 }
 
 #if COREFOUNDATION_HACK_LEVEL >= 3

--- a/Source/main.m
+++ b/Source/main.m
@@ -82,7 +82,28 @@ void Test(void (*func)(void), const char *name)
     });
 }
 
+BOOL TestException(void (^block)(void))
+{
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    @try {
+        block();
+        return NO;
+    }
+    @catch (NSException * e) {        
+        return YES;
+    } @finally {
+      [pool drain];
+    }
+}
+
 #define TEST(func) Test(func, #func)
+
+#define TEST_EXCEPTION(block) do { \
+  if(!TestException(block)) { \
+    gFailureCount++; \
+    NSLog(@"%s:%d: assertion failed: exception was not thrown", __func__, __LINE__); \
+  } \
+} while(0)
 
 #define TEST_ASSERT(cond, ...) do { \
     if(!(cond)) { \
@@ -204,6 +225,28 @@ static void TestNSStringTarget(void)
         [str release];
     });
     [ref release];
+}
+
+static void TestNSConstantTarget(void)
+{
+    if ([MAZeroingWeakRef canRefCoreFoundationObjects]) {
+      NSLog(@"MAZeroingWeakRef can reference CF objects, not testing constant object");
+      return;
+    }
+    
+    NSString *str = @"Constant String";
+    MAZeroingWeakRef *ref = [[MAZeroingWeakRef alloc] initWithTarget: str];
+    WithPool(^{
+      TEST_ASSERT([ref target]);
+      [str release];
+    });
+    [ref release];  
+
+    TEST_EXCEPTION(^{
+      NSString *str = [[NSMutableString alloc] initWithString: @"Not Constant String"];
+      [[[MAZeroingWeakRef alloc] initWithTarget: str] autorelease];
+      [str release];
+    });
 }
 
 static void TestCleanup(void)
@@ -467,6 +510,7 @@ int main(int argc, const char * argv[])
         TEST(TestRefToRef);
         TEST(TestNSArrayTarget);
         TEST(TestNSStringTarget);
+        TEST(TestNSConstantTarget);
         TEST(TestCleanup);
         TEST(TestCFCleanup);
         TEST(TestNotification);

--- a/Source/main.m
+++ b/Source/main.m
@@ -244,8 +244,8 @@ static void TestNSConstantTarget(void)
 
     TEST_EXCEPTION(^{
       NSString *str = [[NSMutableString alloc] initWithString: @"Not Constant String"];
-      [[[MAZeroingWeakRef alloc] initWithTarget: str] autorelease];
-      [str release];
+      MAZeroingWeakRef *ref = [[MAZeroingWeakRef alloc] initWithTarget: str];
+      [ref release];
     });
 }
 

--- a/ZeroingWeakRef.xcodeproj/project.pbxproj
+++ b/ZeroingWeakRef.xcodeproj/project.pbxproj
@@ -136,7 +136,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C2D753FF11E2588500816068 /* Build configuration list for PBXProject "ZeroingWeakRef" */;
 			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = C2D753FA11E2588500816068;
 			productRefGroup = C2D7540811E2588600816068 /* Products */;
 			projectDirPath = "";


### PR DESCRIPTION
This pull request ensures that constant objects are ignored by ZWR. I used the retainCount method to determine whether object is "constant". See [apple docs](http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/Reference/NSObject.html#//apple_ref/occ/intfm/NSObject/retainCount)
