### PR TITLE
Fix compiler warning in newer versions of LLVM by explicitly casting object of type Class to id <NSCopying>

### DIFF
--- a/Source/MAZeroingWeakRef.m
+++ b/Source/MAZeroingWeakRef.m
@@ -665,7 +665,7 @@ static void PatchKVOSubclass(Class class)
 
 static void RegisterCustomSubclass(Class subclass, Class superclass)
 {
-    [gCustomSubclassMap setObject: subclass forKey: superclass];
+    [gCustomSubclassMap setObject: subclass forKey: (id <NSCopying>) superclass];
     [gCustomSubclasses addObject: subclass];
 }
 


### PR DESCRIPTION
Title says it all.
