### PR TITLE
Return removeable handle from addWeakObserver.

### DIFF
--- a/Source/MANotificationCenterAdditions.h
+++ b/Source/MANotificationCenterAdditions.h
@@ -10,6 +10,9 @@
 
 @interface NSNotificationCenter (MAZeroingWeakRefAdditions)
 
-- (void)addWeakObserver: (id)observer selector: (SEL)selector name: (NSString *)name object: (id)object;
+/**
+ * Returns an opaque observation handle that can be removed with NSNotificationCenter's 'removeObserver:'.
+ */
+- (id)addWeakObserver: (id)observer selector: (SEL)selector name: (NSString *)name object: (id)object;
 
 @end

--- a/Source/MANotificationCenterAdditions.m
+++ b/Source/MANotificationCenterAdditions.m
@@ -12,7 +12,7 @@
 
 @implementation NSNotificationCenter (MAZeroingWeakRefAdditions)
 
-- (void)addWeakObserver: (id)observer selector: (SEL)selector name: (NSString *)name object: (id)object
+- (id)addWeakObserver: (id)observer selector: (SEL)selector name: (NSString *)name object: (id)object
 {
     MAZeroingWeakRef *ref = [[MAZeroingWeakRef alloc] initWithTarget: observer];
     
@@ -29,6 +29,8 @@
         [self removeObserver: noteObj];
         [ref autorelease];
     }];
+    
+    return noteObj;
 }
 
 @end


### PR DESCRIPTION
`addWeakObserver:selector:name:object:` now returns an opaque handle that can be removed with NSNotificationCenter's `removeObserver:` method. 

This allows for temporary and cancelable observation.
